### PR TITLE
Reset resting timer completely on listening

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -580,6 +580,7 @@ class Mark2(MycroftSkill):
             Starts countdown to show the idle page.
         """
         # Start idle timer
+        self.cancel_idle_event()
         self.start_idle_event(weak=True)
 
         # Lower the max by half at the start of listener to make sure


### PR DESCRIPTION
This allows speaking visemes to set timeout correctly even if a page has
triggered the event timer