### PR TITLE
Idle update

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -408,9 +408,13 @@ class Mark2(MycroftSkill):
             # If a skill overrides the idle do not switch page
             override_idle = message.data.get('__idle')
             if override_idle is not None:
-                self.log.debug('Cancelling Idle screen')
-                self.cancel_idle_event()
-                self.override_idle = (message, time.monotonic())
+                if isinstance(override_idle, int):
+                    log.info('setting idle timer to {}'.format(override_idle))
+                    self.start_idle_event(override_idle)
+                elif override_idle:
+                    self.log.debug('Cancelling Idle screen')
+                    self.cancel_idle_event()
+                    self.override_idle = (message, time.monotonic())
             elif (message.data['page'] and
                     not message.data['page'][0].endswith('idle.qml')):
                 self.start_idle_event(30)

--- a/__init__.py
+++ b/__init__.py
@@ -407,16 +407,19 @@ class Mark2(MycroftSkill):
 
             # If a skill overrides the idle do not switch page
             override_idle = message.data.get('__idle')
-            if override_idle is not None:
-                if isinstance(override_idle, int):
-                    log.info('setting idle timer to {}'.format(override_idle))
-                    self.start_idle_event(override_idle)
-                elif override_idle:
-                    self.log.debug('Cancelling Idle screen')
-                    self.cancel_idle_event()
-                    self.override_idle = (message, time.monotonic())
+            if isinstance(override_idle, int):
+                # Set the indicated idle timeout
+                self.log.info('Overriding idle timer to'
+                              ' {} seconds'.format(override_idle))
+                self.start_idle_event(override_idle)
+            elif override_idle:
+                # Disable idle screen
+                self.log.debug('Cancelling Idle screen')
+                self.cancel_idle_event()
+                self.override_idle = (message, time.monotonic())
             elif (message.data['page'] and
                     not message.data['page'][0].endswith('idle.qml')):
+                # Set default idle screen timer
                 self.start_idle_event(30)
 
     def on_handler_mouth_reset(self, message):


### PR DESCRIPTION
In addition to `True`the idle_override can now be set to an integer and set the idle timer to an arbitrary length.

In a skill use
```python
self.gui.show_page('awesome_page.qml', override_idle=300')
```