### PR TITLE
Fix volume setting issue

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -211,7 +211,7 @@ class Mark2(MycroftSkill):
         # Update use of wake-up beep
         self._sync_wake_beep_setting()
 
-        self.settings.set_changed_callback(self.on_websettings_changed)
+        self.settings_change_callback = self.on_websettings_changed
 
     def start_listening_thread(self):
         # Start listening thread

--- a/settingsmeta.json
+++ b/settingsmeta.json
@@ -1,6 +1,5 @@
 {
-    "name": "Mark 2 Skill",
-    "color": "#22a7f0",
+    "name": "Mark 2 Controls",
     "skillMetadata": {
         "sections": [
             {


### PR DESCRIPTION
An old volume scaling was left behind making the set volume much to large to be sent as a byte.

This also updates the skill to conform to the latest core changes, settings changed callback definition has been updated and the color has been removed from settingsmeta.