### PR TITLE
start wake visual on wakeword detection

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -131,7 +131,7 @@ class Mark2(MycroftSkill):
                            self.handle_internet_connected)
 
             # Handle the 'waking' visual
-            self.add_event('recognizer_loop:record_begin',
+            self.add_event('recognizer_loop:wakeword',
                            self.handle_listener_started)
             self.add_event('recognizer_loop:record_end',
                            self.handle_listener_ended)


### PR DESCRIPTION
Trigger listener started animations on detection of the wakeword rather than `record_begin` which is emitted a fraction of a second later.