### PR TITLE
Pull the resting screen code into separate class.

### DIFF
--- a/settingsmeta.json
+++ b/settingsmeta.json
@@ -1,5 +1,4 @@
 {
-    "name": "Mark 2 Controls",
     "skillMetadata": {
         "sections": [
             {


### PR DESCRIPTION
The Mark-2 class does a lot of things, this encapsulates the resting screen code in a separate class in an attempt to make things more readable.