### PR TITLE
Ensure listener animation is shown anytime the mic is active.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -136,6 +136,8 @@ class Mark2(MycroftSkill):
             # Handle the 'waking' visual
             self.add_event('recognizer_loop:wakeword',
                            self.handle_listener_started)
+            self.add_event('mycroft.mic.listen',
+                           self.handle_listener_started)
             self.add_event('recognizer_loop:record_end',
                            self.handle_listener_ended)
             self.add_event('mycroft.speech.recognition.unknown',


### PR DESCRIPTION
The animation handler got changed from `record_begin` to `wakeword` to make the animation show more quickly. This had the unintended effect that the animation does not show during Skill prompts.

This also means the `mycroft.mic.listen` message can be used for button push activations.

### How to test
In the mycroft venv trigger the message before and after applying the patch:
```shell
python3 -m mycroft.messagebus.send 'mycroft.mic.listen'
```

or say "hey mycroft, start a timer"