### PR TITLE
Add proper handler for gui release events

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -202,6 +202,9 @@ class Mark2(MycroftSkill):
 
             # Handle device settings events
             self.add_event("mycroft.device.settings", self.handle_device_settings)
+            
+            # Handle GUI release events
+            self.add_event("mycroft.gui.screen.close", self.handle_remove_namespace)
 
             # Use Legacy for QuickSetting delegate
             self.gui.register_handler(
@@ -244,7 +247,7 @@ class Mark2(MycroftSkill):
         self._sync_wake_beep_setting()
 
         self.settings_change_callback = self.on_websettings_changed
-
+        
     ###################################################################
     # System events
     def handle_system_reboot(self, _):
@@ -253,6 +256,14 @@ class Mark2(MycroftSkill):
 
     def handle_system_shutdown(self, _):
         subprocess.call(["/usr/bin/systemctl", "poweroff"])
+        
+    def handle_remove_namespace(self, message):
+        get_skill_namespace = message.data.get("skill_id", "")
+        if get_skill_namespace:
+            self.bus.emit(Message("gui.clear.namespace",
+                                  {"__from": get_skill_namespace}))
+        self.resting_screen.cancel_override()
+        self.cancel_scheduled_event("IdleCheck")
 
     ###################################################################
     # Idle screen mechanism


### PR DESCRIPTION
#### Description
Adds a proper handler for self.gui.release() emitted events

This handler is responsible for removing the skill from the namespace using "gui.clear.namespace" and cancelling all idle screen events associated with it.  

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [x] Bugfix
- [x] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Test against: https://github.com/MycroftAI/mycroft-core/pull/2683
and any skill that incorporates "self.gui.release()" method 

#### CLA
- [x] yes
