### PR TITLE
Clear awake face manually

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -365,8 +365,13 @@ class Mark2(MycroftSkill):
 
     def on_handler_awoken(self, _):
         """ Show awake face when sleep ends. """
+        # TODO move these GUI pages to the Naptime Skill.
         self.gui["state"] = "awake"
         self.gui.show_page("all.qml")
+        # By default Mark II Skill pages override idle
+        time.sleep(10)
+        self.resting_screen.show()
+
 
     def on_handler_complete(self, message):
         """ When a skill finishes executing clear the showing page state. """


### PR DESCRIPTION
#### Description
By default Mark II Skill pages are shown until intentionally cleared eg the Settings pages.

This manually returns the screen to it's normal resting screen after the device as awoken.

Also included a TODO to shift these screens to the Naptime Skill.

#### Type of PR
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Hey Mycroft, go to sleep
Hey Mycroft, wake up