### PR TITLE
Hide Factory Reset option in settings

### DIFF
--- a/ui/settings/SettingsModel.qml
+++ b/ui/settings/SettingsModel.qml
@@ -13,12 +13,12 @@ ListModel {
         settingEvent: "mycroft.device.settings.homescreen"
         settingCall: "show homescreen settings"
     }
-    ListElement {
-        settingIcon: "circular-arrow-shape"
-        settingName: "Factory Reset"
-        settingEvent: "mycroft.device.settings.reset"
-        settingCall: ""
-    }
+    // ListElement {
+    //     settingIcon: "circular-arrow-shape"
+    //     settingName: "Factory Reset"
+    //     settingEvent: "mycroft.device.settings.reset"
+    //     settingCall: ""
+    // }
     ListElement {
         settingIcon: "download"
         settingName: "Update Device"


### PR DESCRIPTION
#### Description
The factory reset functionality has not yet been implemented in the Pantacor build.
This PR hides the button in the settings until that is implemented as it is confusing for users.

#### Type of PR
- [x] Bugfix

#### Testing
Load modified Skill - button should be gone, everything else as normal.