### PR TITLE
changed how an idle screen is identified

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -329,6 +329,11 @@ class Mark2(MycroftSkill):
 
             # If a skill overrides the idle do not switch page
             override_idle = message.data.get("__idle")
+            is_idle_screen = False
+            for screen in self.resting_screen.screens.values():
+                if screen in message.data["page"][0]:
+                    is_idle_screen = True
+                    break
             if override_idle is True:
                 # Disable idle screen
                 self.log.debug("Cancelling Idle screen")
@@ -340,9 +345,7 @@ class Mark2(MycroftSkill):
                 )
                 self.resting_screen.override(None)
                 self.start_idle_event(override_idle)
-            elif message.data["page"] and not message.data["page"][0].endswith(
-                "idle.qml"
-            ):
+            elif message.data["page"] and not is_idle_screen:
                 # Check if the idle override has been set and if this call of
                 # show_page should deactivate a previous idle override
                 # This is only possible if the page is from the same skill


### PR DESCRIPTION
#### Description
Changes how a condition in an "if" statement determines if a page is an idle screen.  Previously the screen name had to end with "idle.qml", which seemed limiting.  This change will look instead at the list of registered resting screens and match the screen name to one of those.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.

- [ ] Feature implementation
- [X] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Resting screen should work as always.

#### Documentation
N/A
