### PR TITLE
When no "selected" setting existed, the default was not being saved

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -66,7 +66,9 @@ class RestingScreen:
         self.override_set_time = time.monotonic()
 
         # Preselect Homescreen Skill as resting screen
-        self.gui["selected"] = self.settings.get("selected", "Mycroft Homescreen")
+        if "selected" not in self.settings:
+            self.settings["selected"] = "Mycroft Homescreen"
+        self.gui["selected"] = self.settings["selected"]
         self.gui.set_on_gui_changed(self.save)
 
     def on_register(self, message):


### PR DESCRIPTION
#### Description
Fixes a bug where the selected resting screen was not saved to the skill settings when the default resting screen is selected due to the absence of the setting at initialization time.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
- [X] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
After restarting the skill, the default resting screen should appear in the settings.json file for this skill.

#### Documentation
N/A

