### PR TITLE
Re-add loading screen

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -235,8 +235,8 @@ class Mark2(MycroftSkill):
             self.add_event("system.shutdown", self.handle_system_shutdown)
 
             # Show loading screen while starting up skills.
-            # self.gui['state'] = 'loading'
-            # self.gui.show_page('all.qml')
+            self.gui['state'] = 'loading'
+            self.gui.show_page('all.qml')
 
             # Collect Idle screens and display if skill is restarted
             self.resting_screen.collect()

--- a/ui/all.qml
+++ b/ui/all.qml
@@ -4,7 +4,7 @@ import QtQuick.Controls 2.0
 import org.kde.kirigami 2.5 as Kirigami
 import Mycroft 1.0 as Mycroft
 
-Mycroft.Delegate {
+Mycroft.CardDelegate {
     id: mainLoaderView
 
     property var pageToLoad: sessionData.state

--- a/ui/loading.qml
+++ b/ui/loading.qml
@@ -8,21 +8,20 @@ import Mycroft 1.0 as Mycroft
 Item {
     id: root
 
-    Mycroft.AutoFitLabel {
+    Label {
         font.weight: Font.Bold
         Layout.fillWidth: true
-        Layout.preferredHeight: proportionalGridUnit * 40
-        rightPadding: -font.pixelSize * 0.1
-        font.family: "Noto Sans"
-        font.pixelSize: 50
+        anchors.horizontalCenter: parent.horizontalCenter
+        Layout.preferredHeight: Mycroft.Units.gridUnit * 12
+        font.pixelSize: Mycroft.Units.gridUnit * 4
         color: "#22a7f0"
-        text: "Loading..."
+        text: "Loading Skills..."
     }
 
-    BusyIndicator {
-        anchors.centerIn: parent
-        width: root.contentWidth / 2
-        height: root.contentWidth / 2
+    Mycroft.BusyIndicator {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: Mycroft.Units.gridUnit * 4
         running: true
     }
 }


### PR DESCRIPTION
#### Description
Re-enables the loading screen in the Mark II Skill. Also switches the Skill to use the `Mycroft.CardDelegate`.

Requires design review before merging.

#### Type of PR
- [ ] Bugfix
- [x] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Load the change and restart your device (or just the Skills service).