### PR TITLE
Add About page to Additional Settings displaying version info.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -30,6 +30,13 @@ from mycroft.util.log import LOG
 from mycroft.util.parse import normalize
 from mycroft import MycroftSkill, intent_handler
 
+from .skill.versions import (
+    get_mycroft_build_datetime,
+    get_mycroft_core_commit,
+    get_mycroft_core_version,
+    get_skill_update_datetime
+)
+
 
 def compare_origin(msg1, msg2):
     """Compare the origin Skill of two Messages.
@@ -221,6 +228,9 @@ class Mark2(MycroftSkill):
             )
             self.gui.register_handler(
                 "mycroft.device.settings.update", self.handle_device_update_settings
+            )
+            self.gui.register_handler(
+                "mycroft.device.settings.about", self.show_device_settings_about
             )
             self.gui.register_handler(
                 "mycroft.device.show.idle", self.resting_screen.show
@@ -681,6 +691,17 @@ class Mark2(MycroftSkill):
     def handle_device_update_settings(self, _):
         """ Display device update settings page. """
         self.gui["state"] = "settings/updatedevice_settings"
+        self.gui.show_page("all.qml")
+
+    @intent_handler("device.settings.about.page.intent")
+    def show_device_settings_about(self, _):
+        """ Display device update settings page. """
+        self.gui["mycroftCoreVersion"] = get_mycroft_core_version()
+        self.gui["mycroftCoreCommit"] = get_mycroft_core_commit()
+        self.gui["mycroftContainerBuildDate"] = get_mycroft_build_datetime()
+        skills_repo_path = f"{self.config_core['data_dir']}/.skills-repo"
+        self.gui["mycroftSkillsUpdateDate"] = get_skill_update_datetime(skills_repo_path)
+        self.gui["state"] = "settings/about"
         self.gui.show_page("all.qml")
 
 

--- a/locale/en-us/device.settings.about.page.intent
+++ b/locale/en-us/device.settings.about.page.intent
@@ -1,0 +1,4 @@
+show the about page
+show me your version (info|information)
+show me what version you are running
+show me when you last updated

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 astral==1.4
 arrow==0.12.0
+GitPython

--- a/skill/__init__.py
+++ b/skill/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/skill/versions.py
+++ b/skill/versions.py
@@ -1,0 +1,66 @@
+# Copyright 2021 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from git import Git
+
+from mycroft import MYCROFT_ROOT_PATH
+from mycroft.version import CORE_VERSION_STR
+
+
+def get_mycroft_build_datetime():
+    """Get the Mycroft container build date from a file, if it exists."""
+    build_datetime = ""
+    build_info_path = Path("/etc/mycroft/build-info.json")
+    if build_info_path.is_file():
+        with open(build_info_path) as build_info_file:
+            build_info = json.loads(build_info_file.read())
+            build_datetime = build_info.get("build_date", "")
+    # Do not include seconds in timestamp
+    return build_datetime[:-3]
+
+
+def get_mycroft_core_commit():
+    """Get the latest commit info for Mycroft-Core."""
+    commit_string = ''
+    core_repo = Git(MYCROFT_ROOT_PATH)
+    branch = core_repo.branch("--show-current")
+    if not branch:
+        # It's in a detached head state so is not reporting branch.
+        branch = "feature/mark-2"
+    commit_hash = core_repo.log("-n 1", "--pretty=format:%h")[:7]
+    commit_string = f"{branch}@{commit_hash}"
+    return commit_string
+
+
+def get_mycroft_core_version():
+    """Get the reported version number for Mycroft-Core.
+
+    Note: if running off a feature branch or dev, 
+    the last point release of core will be returned.
+    """
+    return CORE_VERSION_STR
+
+
+def get_skill_update_datetime(skills_repo_path):
+    """Get the date the Skills Marketplace last updated."""
+    skills_repo = Git(skills_repo_path)
+    last_commit_timestamp = skills_repo.log("-1", "--format=%ct")
+    last_commit_date_time = datetime.utcfromtimestamp(
+        int(last_commit_timestamp)
+    )
+    return last_commit_date_time.strftime("%Y-%m-%d %H:%M")

--- a/ui/settings/SettingsModel.qml
+++ b/ui/settings/SettingsModel.qml
@@ -19,10 +19,16 @@ ListModel {
     //     settingEvent: "mycroft.device.settings.reset"
     //     settingCall: ""
     // }
+    // ListElement {
+    //     settingIcon: "download"
+    //     settingName: "Update Device"
+    //     settingEvent: "mycroft.device.settings.update"
+    //     settingCall: ""
+    // }
     ListElement {
-        settingIcon: "download"
-        settingName: "Update Device"
-        settingEvent: "mycroft.device.settings.update"
-        settingCall: "" 
+        settingIcon: "question"
+        settingName: "About"
+        settingEvent: "mycroft.device.settings.about"
+        settingCall: "show about page"
     }
 }

--- a/ui/settings/about.qml
+++ b/ui/settings/about.qml
@@ -1,0 +1,170 @@
+// Copyright 2021, Mycroft AI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Display information about the current system including version of core.
+*/
+
+import QtQuick.Layouts 1.4
+import QtQuick 2.4
+import QtQuick.Controls 2.0
+import org.kde.kirigami 2.5 as Kirigami
+import org.kde.plasma.core 2.0 as PlasmaCore
+import Mycroft 1.0 as Mycroft
+
+Item {
+    id: aboutSettingsView
+    anchors.fill: parent
+
+    Item {
+        id: topArea
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        height: Kirigami.Units.gridUnit * 2
+        
+        Kirigami.Heading {
+            id: aboutSettingPageTextHeading
+            level: 1
+            wrapMode: Text.WordWrap
+            anchors.centerIn: parent
+            font.bold: true
+            text: "About"
+            color: Kirigami.Theme.linkColor
+        }
+    }
+
+    Item {
+        anchors.top: topArea.bottom
+        anchors.topMargin: Kirigami.Units.largeSpacing
+        anchors.leftMargin: Mycroft.Units.gridUnit * 12
+        anchors.rightMargin: Mycroft.Units.gridUnit * 12
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: areaSep.top
+        
+        ColumnLayout {
+            anchors.left: parent.left
+            anchors.right: parent.right
+            spacing: Kirigami.Units.smallSpacing
+            
+            Kirigami.Heading {
+                id: versionsHeading
+                level: 2
+                Layout.alignment: Qt.AlignHCenter
+                text: "Mycroft-core"
+            }
+            
+            Item {
+                Layout.fillWidth: true
+                Layout.preferredHeight: Kirigami.Units.smallSpacing
+            }
+            
+            Label {
+                id: mycroftCoreVersionLabel
+                Layout.alignment: Qt.AlignHCenter
+                text: "Version: " + sessionData.mycroftCoreVersion
+            }
+            
+            Label {
+                id: mycroftCoreCommitLabel
+                Layout.alignment: Qt.AlignHCenter
+                text: "Commit: " + sessionData.mycroftCoreCommit
+            }
+            
+            Item {
+                Layout.fillWidth: true
+                Layout.preferredHeight: Kirigami.Units.largeSpacing
+            }
+            
+            Kirigami.Separator {
+                Layout.fillWidth: true
+            }
+            
+            Item {
+                Layout.fillWidth: true
+                Layout.preferredHeight: Kirigami.Units.largeSpacing
+            }
+
+            Kirigami.Heading {
+                id: updateDateHeading
+                level: 2
+                Layout.alignment: Qt.AlignHCenter
+                text: "Last updated"
+            }
+            
+            Item {
+                Layout.fillWidth: true
+                Layout.preferredHeight: Kirigami.Units.smallSpacing
+            }
+            
+            Label {
+                id: mycroftContainerBuildDateLabel
+                Layout.alignment: Qt.AlignHCenter
+                text: "Mycroft Container: " + sessionData.mycroftContainerBuildDate
+            }
+            
+            Label {
+                id: mycroftSkillsUpdateDateLabel
+                Layout.alignment: Qt.AlignHCenter
+                text: "Mycroft Skills: " + sessionData.mycroftSkillsUpdateDate
+            }
+        }
+    }
+
+    Kirigami.Separator {
+        id: areaSep
+        anchors.bottom: bottomArea.top
+        anchors.left: parent.left
+        anchors.right: parent.right
+        height: 1
+    }
+    
+    Item {
+        id: bottomArea
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: Kirigami.Units.largeSpacing * 1.15
+        height: backIcon.implicitHeight + Kirigami.Units.largeSpacing * 1.15
+
+        RowLayout {
+            anchors.fill: parent
+            
+            Kirigami.Icon {
+                id: backIcon
+                source: "go-previous"
+                Layout.preferredHeight: Kirigami.Units.iconSizes.medium
+                Layout.preferredWidth: Kirigami.Units.iconSizes.medium
+            }
+            
+            Kirigami.Heading {
+                level: 2
+                wrapMode: Text.WordWrap
+                font.bold: true
+                text: "Device Settings"
+                Layout.fillWidth: true
+                Layout.preferredHeight: Kirigami.Units.gridUnit * 2
+            }
+        }
+        
+        MouseArea {
+            anchors.fill: parent
+            onClicked: {
+                triggerGuiEvent("mycroft.device.settings", {})
+            }
+        }
+    }
+} 
+ 


### PR DESCRIPTION
#### Description
It also includes the container build and Skills update dates that are currently displayed on the homescreen for dev devices.

This hides the update page as there is not yet a mechanism to trigger updates locally from the device.

#### Type of PR
- [ ] Bugfix
- [x] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Pull down menu, select Additional Settings, select About