### PR TITLE
Add Mycroft and Pantacor device IDs to about page

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -35,7 +35,7 @@ from .skill.versions import (
     get_mycroft_build_datetime,
     get_mycroft_core_commit,
     get_mycroft_core_version,
-    get_skill_update_datetime
+    get_skill_update_datetime,
 )
 
 
@@ -154,8 +154,8 @@ class RestingScreen:
 class Mark2(MycroftSkill):
     """
     The Mark2 skill handles much of the gui activities related to Mycroft's
-    core functionality. 
-    
+    core functionality.
+
     This currently includes showing system loading screens, managing the
     resting screens, and handling system signals. Thinking and Speaking
     animations are also available.
@@ -211,7 +211,7 @@ class Mark2(MycroftSkill):
 
             # Handle device settings events
             self.add_event("mycroft.device.settings", self.handle_device_settings)
-            
+
             # Handle GUI release events
             self.add_event("mycroft.gui.screen.close", self.handle_remove_namespace)
 
@@ -259,7 +259,7 @@ class Mark2(MycroftSkill):
         self._sync_wake_beep_setting()
 
         self.settings_change_callback = self.on_websettings_changed
-        
+
     ###################################################################
     # System events
     def handle_system_reboot(self, _):
@@ -268,12 +268,13 @@ class Mark2(MycroftSkill):
 
     def handle_system_shutdown(self, _):
         subprocess.call(["/usr/bin/systemctl", "poweroff"])
-        
+
     def handle_remove_namespace(self, message):
         get_skill_namespace = message.data.get("skill_id", "")
         if get_skill_namespace:
-            self.bus.emit(Message("gui.clear.namespace",
-                                  {"__from": get_skill_namespace}))
+            self.bus.emit(
+                Message("gui.clear.namespace", {"__from": get_skill_namespace})
+            )
         self.resting_screen.cancel_override()
         self.cancel_scheduled_event("IdleCheck")
 
@@ -319,7 +320,7 @@ class Mark2(MycroftSkill):
             return
 
     def on_gui_page_interaction(self, _):
-        """ Reset idle timer to 30 seconds when page is flipped. """
+        """Reset idle timer to 30 seconds when page is flipped."""
         self.log.debug("Resetting idle counter to 30 seconds")
         self.start_idle_event(30)
 
@@ -358,21 +359,22 @@ class Mark2(MycroftSkill):
                 # show_page should deactivate a previous idle override
                 # This is only possible if the page is from the same skill
                 self.log.info("Cancelling idle override")
-                if self.resting_screen.override_idle is not None and \
-                   override_idle is False and \
-                   compare_origin(message,
-                                  self.resting_screen.override_idle[0]):
+                if (
+                    self.resting_screen.override_idle is not None
+                    and override_idle is False
+                    and compare_origin(message, self.resting_screen.override_idle[0])
+                ):
                     # Remove the idle override page if override is set to false
                     self.resting_screen.cancel_override()
                 # Set default idle screen timer
                 self.start_idle_event(30)
 
     def on_handler_mouth_reset(self, _):
-        """ Restore viseme to a smile. """
+        """Restore viseme to a smile."""
         pass
 
     def on_handler_complete(self, message):
-        """ When a skill finishes executing clear the showing page state. """
+        """When a skill finishes executing clear the showing page state."""
         handler = message.data.get("handler", "")
         # Ignoring handlers from this skill and from the background clock
         if "Mark2" in handler:
@@ -445,18 +447,18 @@ class Mark2(MycroftSkill):
     # Manage network
 
     def handle_internet_connected(self, _):
-        """ System came online later after booting. """
+        """System came online later after booting."""
         self.enclosure.mouth_reset()
 
     #####################################################################
     # Web settings
 
     def on_websettings_changed(self):
-        """ Update use of wake-up beep. """
+        """Update use of wake-up beep."""
         self._sync_wake_beep_setting()
 
     def _sync_wake_beep_setting(self):
-        """ Update "use beep" global config from skill settings. """
+        """Update "use beep" global config from skill settings."""
         config = Configuration.get()
         use_beep = self.settings.get("use_listening_beep", False)
         if not config["confirm_listening"] == use_beep:
@@ -667,7 +669,7 @@ class Mark2(MycroftSkill):
 
     @intent_handler("device.settings.intent")
     def handle_device_settings(self, _):
-        """ Display device settings page. """
+        """Display device settings page."""
         self.gui["state"] = "settings/settingspage"
         self.gui.show_page("all.qml")
 
@@ -676,8 +678,10 @@ class Mark2(MycroftSkill):
         """
         display homescreen settings page
         """
-        screens = [{"screenName": s, "screenID": self.resting_screen.screens[s]}
-                   for s in self.resting_screen.screens]
+        screens = [
+            {"screenName": s, "screenID": self.resting_screen.screens[s]}
+            for s in self.resting_screen.screens
+        ]
         self.gui["idleScreenList"] = {"screenBlob": screens}
         self.gui["selectedScreen"] = self.gui["selected"]
         self.gui["state"] = "settings/homescreen_settings"
@@ -685,23 +689,25 @@ class Mark2(MycroftSkill):
 
     @intent_handler("device.reset.settings.intent")
     def handle_device_factory_reset_settings(self, _):
-        """ Display device factory reset settings page. """
+        """Display device factory reset settings page."""
         self.gui["state"] = "settings/factoryreset_settings"
         self.gui.show_page("all.qml")
 
     def handle_device_update_settings(self, _):
-        """ Display device update settings page. """
+        """Display device update settings page."""
         self.gui["state"] = "settings/updatedevice_settings"
         self.gui.show_page("all.qml")
 
     @intent_handler("device.settings.about.page.intent")
     def show_device_settings_about(self, _):
-        """ Display device update settings page. """
+        """Display device update settings page."""
         self.gui["mycroftCoreVersion"] = get_mycroft_core_version()
         self.gui["mycroftCoreCommit"] = get_mycroft_core_commit()
         self.gui["mycroftContainerBuildDate"] = get_mycroft_build_datetime()
         skills_repo_path = f"{self.config_core['data_dir']}/.skills-repo"
-        self.gui["mycroftSkillsUpdateDate"] = get_skill_update_datetime(skills_repo_path)
+        self.gui["mycroftSkillsUpdateDate"] = get_skill_update_datetime(
+            skills_repo_path
+        )
         self.gui["deviceName"] = get_device_name()
         self.gui["mycroftUUID"] = get_mycroft_uuid()
         self.gui["pantacorDeviceId"] = get_pantacor_device_id()

--- a/__init__.py
+++ b/__init__.py
@@ -30,7 +30,7 @@ from mycroft.util.log import LOG
 from mycroft.util.parse import normalize
 from mycroft import MycroftSkill, intent_handler
 
-from .skill.device_id import get_mycroft_uuid, get_pantacor_device_id
+from .skill.device_id import get_device_name, get_mycroft_uuid, get_pantacor_device_id
 from .skill.versions import (
     get_mycroft_build_datetime,
     get_mycroft_core_commit,
@@ -702,6 +702,7 @@ class Mark2(MycroftSkill):
         self.gui["mycroftContainerBuildDate"] = get_mycroft_build_datetime()
         skills_repo_path = f"{self.config_core['data_dir']}/.skills-repo"
         self.gui["mycroftSkillsUpdateDate"] = get_skill_update_datetime(skills_repo_path)
+        self.gui["deviceName"] = get_device_name()
         self.gui["mycroftUUID"] = get_mycroft_uuid()
         self.gui["pantacorDeviceId"] = get_pantacor_device_id()
         self.gui["state"] = "settings/about"

--- a/__init__.py
+++ b/__init__.py
@@ -30,6 +30,7 @@ from mycroft.util.log import LOG
 from mycroft.util.parse import normalize
 from mycroft import MycroftSkill, intent_handler
 
+from .skill.device_id import get_mycroft_uuid, get_pantacor_device_id
 from .skill.versions import (
     get_mycroft_build_datetime,
     get_mycroft_core_commit,
@@ -701,6 +702,8 @@ class Mark2(MycroftSkill):
         self.gui["mycroftContainerBuildDate"] = get_mycroft_build_datetime()
         skills_repo_path = f"{self.config_core['data_dir']}/.skills-repo"
         self.gui["mycroftSkillsUpdateDate"] = get_skill_update_datetime(skills_repo_path)
+        self.gui["mycroftUUID"] = get_mycroft_uuid()
+        self.gui["pantacorDeviceId"] = get_pantacor_device_id()
         self.gui["state"] = "settings/about"
         self.gui.show_page("all.qml")
 

--- a/skill/device_id.py
+++ b/skill/device_id.py
@@ -12,9 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mycroft.api import _get_pantacor_device_id
+from mycroft.api import DeviceApi, _get_pantacor_device_id
 from mycroft.identity import IdentityManager
+from mycroft.util import LOG
 
+
+def get_device_name():
+    try:
+        return DeviceApi().get()["name"]
+    except Exception as err:
+        LOG.exception("API Error", err)
+        return ":error:"
 
 def get_mycroft_uuid():
     """Get the UUID of a Mycroft device paired with the Mycroft backend."""

--- a/skill/device_id.py
+++ b/skill/device_id.py
@@ -24,15 +24,15 @@ def get_device_name():
         LOG.exception("API Error", err)
         return ":error:"
 
+
 def get_mycroft_uuid():
     """Get the UUID of a Mycroft device paired with the Mycroft backend."""
     identity = IdentityManager.get()
     return identity.uuid
+
 
 def get_pantacor_device_id():
     """Get the Pantacor device-id for devices using the Pantacor update system."""
     # TODO this uses the temporary solution in the feature/mark-2 branch.
     # It should be replaced when a better solution is available.
     return _get_pantacor_device_id()
-
-

--- a/skill/device_id.py
+++ b/skill/device_id.py
@@ -1,0 +1,30 @@
+# Copyright 2021 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mycroft.api import _get_pantacor_device_id
+from mycroft.identity import IdentityManager
+
+
+def get_mycroft_uuid():
+    """Get the UUID of a Mycroft device paired with the Mycroft backend."""
+    identity = IdentityManager.get()
+    return identity.uuid
+
+def get_pantacor_device_id():
+    """Get the Pantacor device-id for devices using the Pantacor update system."""
+    # TODO this uses the temporary solution in the feature/mark-2 branch.
+    # It should be replaced when a better solution is available.
+    return _get_pantacor_device_id()
+
+

--- a/skill/versions.py
+++ b/skill/versions.py
@@ -36,7 +36,7 @@ def get_mycroft_build_datetime():
 
 def get_mycroft_core_commit():
     """Get the latest commit info for Mycroft-Core."""
-    commit_string = ''
+    commit_string = ""
     core_repo = Git(MYCROFT_ROOT_PATH)
     branch = core_repo.branch("--show-current")
     if not branch:
@@ -50,7 +50,7 @@ def get_mycroft_core_commit():
 def get_mycroft_core_version():
     """Get the reported version number for Mycroft-Core.
 
-    Note: if running off a feature branch or dev, 
+    Note: if running off a feature branch or dev,
     the last point release of core will be returned.
     """
     return CORE_VERSION_STR
@@ -60,7 +60,5 @@ def get_skill_update_datetime(skills_repo_path):
     """Get the date the Skills Marketplace last updated."""
     skills_repo = Git(skills_repo_path)
     last_commit_timestamp = skills_repo.log("-1", "--format=%ct")
-    last_commit_date_time = datetime.utcfromtimestamp(
-        int(last_commit_timestamp)
-    )
+    last_commit_date_time = datetime.utcfromtimestamp(int(last_commit_timestamp))
     return last_commit_date_time.strftime("%Y-%m-%d %H:%M")

--- a/ui/settings/about.qml
+++ b/ui/settings/about.qml
@@ -33,7 +33,7 @@ Item {
         anchors.right: parent.right
         anchors.top: parent.top
         height: Kirigami.Units.gridUnit * 2
-        
+
         Kirigami.Heading {
             id: aboutSettingPageTextHeading
             level: 1
@@ -45,53 +45,61 @@ Item {
         }
     }
 
-    Item {
+    Flickable {
         anchors.top: topArea.bottom
-        anchors.topMargin: Kirigami.Units.largeSpacing
-        anchors.leftMargin: Mycroft.Units.gridUnit * 12
-        anchors.rightMargin: Mycroft.Units.gridUnit * 12
+        anchors.topMargin: Mycroft.Units.largeSpacing
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.bottom: areaSep.top
-        
+        anchors.bottomMargin: Mycroft.Units.largeSpacing
+        clip: true
+        contentHeight: contentColumnLayout.implicitHeight
+
         ColumnLayout {
-            anchors.left: parent.left
-            anchors.right: parent.right
+            id: contentColumnLayout
+            anchors.fill: parent
+            anchors.leftMargin: Mycroft.Units.gridUnit * 10
+            anchors.rightMargin: Mycroft.Units.gridUnit * 10
             spacing: Kirigami.Units.smallSpacing
-            
+
+            Item {
+                Layout.fillWidth: true
+                Layout.preferredHeight: Kirigami.Units.largeSpacing
+            }
+
             Kirigami.Heading {
                 id: versionsHeading
                 level: 2
                 Layout.alignment: Qt.AlignHCenter
                 text: "Mycroft-core"
             }
-            
+
             Item {
                 Layout.fillWidth: true
                 Layout.preferredHeight: Kirigami.Units.smallSpacing
             }
-            
+
             Label {
                 id: mycroftCoreVersionLabel
                 Layout.alignment: Qt.AlignHCenter
                 text: "Version: " + sessionData.mycroftCoreVersion
             }
-            
+
             Label {
                 id: mycroftCoreCommitLabel
                 Layout.alignment: Qt.AlignHCenter
                 text: "Commit: " + sessionData.mycroftCoreCommit
             }
-            
+
             Item {
                 Layout.fillWidth: true
                 Layout.preferredHeight: Kirigami.Units.largeSpacing
             }
-            
+
             Kirigami.Separator {
                 Layout.fillWidth: true
             }
-            
+
             Item {
                 Layout.fillWidth: true
                 Layout.preferredHeight: Kirigami.Units.largeSpacing
@@ -103,22 +111,65 @@ Item {
                 Layout.alignment: Qt.AlignHCenter
                 text: "Last updated"
             }
-            
+
             Item {
                 Layout.fillWidth: true
                 Layout.preferredHeight: Kirigami.Units.smallSpacing
             }
-            
+
             Label {
                 id: mycroftContainerBuildDateLabel
                 Layout.alignment: Qt.AlignHCenter
                 text: "Mycroft Container: " + sessionData.mycroftContainerBuildDate
             }
-            
+
             Label {
                 id: mycroftSkillsUpdateDateLabel
                 Layout.alignment: Qt.AlignHCenter
                 text: "Mycroft Skills: " + sessionData.mycroftSkillsUpdateDate
+            }
+
+            Item {
+                Layout.fillWidth: true
+                Layout.preferredHeight: Kirigami.Units.largeSpacing
+            }
+
+            Kirigami.Separator {
+                Layout.fillWidth: true
+            }
+
+            Item {
+                Layout.fillWidth: true
+                Layout.preferredHeight: Kirigami.Units.largeSpacing
+            }
+
+            Kirigami.Heading {
+                id: deviceIdHeading
+                level: 2
+                Layout.alignment: Qt.AlignHCenter
+                text: "Device Identification"
+            }
+
+            Item {
+                Layout.fillWidth: true
+                Layout.preferredHeight: Kirigami.Units.smallSpacing
+            }
+
+            Label {
+                id: mycroftUUIDLabel
+                Layout.alignment: Qt.AlignHCenter
+                text: "Mycroft UUID: " + sessionData.mycroftUUID
+            }
+
+            Label {
+                id: pantacorDeviceIdLabel
+                Layout.alignment: Qt.AlignHCenter
+                text: "Pantacor ID: " + sessionData.pantacorDeviceId
+            }
+
+            Item {
+                Layout.fillWidth: true
+                Layout.preferredHeight: Kirigami.Units.largeSpacing * 2
             }
         }
     }
@@ -130,7 +181,7 @@ Item {
         anchors.right: parent.right
         height: 1
     }
-    
+
     Item {
         id: bottomArea
         anchors.left: parent.left

--- a/ui/settings/about.qml
+++ b/ui/settings/about.qml
@@ -156,6 +156,12 @@ Item {
             }
 
             Label {
+                id: deviceNameLabel
+                Layout.alignment: Qt.AlignHCenter
+                text: "Device Name: " + sessionData.deviceName
+            }
+
+            Label {
                 id: mycroftUUIDLabel
                 Layout.alignment: Qt.AlignHCenter
                 text: "Mycroft UUID: " + sessionData.mycroftUUID


### PR DESCRIPTION
#### Description
Adds Mycroft UUID and Pantacor Device-ID to the about page for easier access. This means that users no longer need to ssh into their device to get them. Particularly problematic if you're having problems with network connectivity. 

To fit the extra content on the page, it has a new Flickable (think scrollable) element courtesy of @AIIX.

#### Type of PR
- [x] Feature implementation

#### Testing
1. Add to a Mark II
2. Pull down menu
3. Select "Additional Settings" > "About"

#### CLA
- [x] Yes