### PR TITLE
Prevent Skill crash on non-mark-ii device

### DIFF
--- a/skill/device_id.py
+++ b/skill/device_id.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mycroft.api import DeviceApi, _get_pantacor_device_id
+from mycroft.api import DeviceApi
 from mycroft.identity import IdentityManager
 from mycroft.util import LOG
 
@@ -35,4 +35,11 @@ def get_pantacor_device_id():
     """Get the Pantacor device-id for devices using the Pantacor update system."""
     # TODO this uses the temporary solution in the feature/mark-2 branch.
     # It should be replaced when a better solution is available.
-    return _get_pantacor_device_id()
+    device_id = "unknown"
+    try:
+        from mycroft.api import _get_pantacor_device_id
+
+        device_id = _get_pantacor_device_id()
+    except ImportError:
+        LOG.error("This device is likely not a real Mark II.")
+    return device_id


### PR DESCRIPTION
#### Description
This moves the import of a Mark II only function to a try block.

Whilst it should be expected on a real Mark II. If you are developing on another machine, this prevents being able to run the Mark II Skill and thus emulate the Mark II display as well.

#### Type of PR
- [x] Bugfix

#### Testing
Run the Skill on a desktop using the dev branch of mycroft-core

#### CLA
- [x] Yes